### PR TITLE
update way to take home dir and work with paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+  "path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -17,8 +18,6 @@ import (
 
 	"github.com/fatih/color"
 	"gopkg.in/ini.v1"
-
-	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -192,7 +191,7 @@ func menuInput(userFlag bool) (string, string, string, int32, string) {
 
 // Get the home directory location
 func homeDir() string {
-	homeDir, err := homedir.Dir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Printf("Unable to get home directory location \nError: %v", err.Error())
 		os.Exit(1)
@@ -402,9 +401,9 @@ func main() {
 	// Run the menu parser, retrieve results
 	awsCreds, awsRegion, awsProfile, duration, tokenCode := menuInput(*userFlag)
 
-	// Use homeDir function to get AWS config and credentials file absolute path
-	awsCredsPath = homeDir() + "/.aws/credentials"
-	awsConfigPath = homeDir() + "/.aws/config"
+  var awsDir = path.Join(homeDir(), ".aws")
+	awsCredsPath = path.Join(awsDir, "credentials")
+	awsConfigPath = path.Join(awsDir, "config")
 
 	// Get a Session Token or Assume a Role
 	if *userFlag {


### PR DESCRIPTION
Starting with Go 1.12, there is [os.UserHomeDir()](https://pkg.go.dev/os#UserHomeDir) that should replace the `github.com/mitchellh/go-homedir` package without any issues.

A safe cross-platform way to work with paths is [path.Join](https://pkg.go.dev/path#Join) instead of string concatenation. Windows doesn't care if there is a mixture of back and forward slashes, but it's better to be on the safe side :)